### PR TITLE
Derivative nomenclature compatible with sympy's latex packages

### DIFF
--- a/symb_tools.py
+++ b/symb_tools.py
@@ -2623,6 +2623,9 @@ def perform_time_derivative(expr, func_symbols, prov_deriv_symbols=None,
     but different sets of assumptions (real=True etc.) are handled as
     different symbols by sympy. Here we dont want this. If the name of
     func_symbols occurs in expr this is sufficient for being regarded as equal.
+
+    assumptions like 'real=True' can be passed to the symbol generation via
+    kwargs
     """
 
     if not t_symbol:
@@ -2641,9 +2644,6 @@ def perform_time_derivative(expr, func_symbols, prov_deriv_symbols=None,
 
     derivs1 = [[f.diff(t, ord) for f in funcs] for ord in range(order, 0, -1)]
 
-    if not kwargs:
-        # assumptions for the symbols (facilitating the postprocessing)
-        kwargs ={"real": True}
 
     def extended_name_symb(base, ord):
         if isinstance(base, sp.Symbol):
@@ -2687,7 +2687,6 @@ def perform_time_derivative(expr, func_symbols, prov_deriv_symbols=None,
 
         elif not new_name:
             new_name = base_order + r'dot' + trailing_number
-
 
         if ord == 1:
             return sp.Symbol(new_name, **kwargs)

--- a/test_symb_tools.py
+++ b/test_symb_tools.py
@@ -77,6 +77,28 @@ class SymbToolsTest(unittest.TestCase):
                                                  (adot, bdot)+ (addot, bddot) )
         self.assertEquals(f1d_2, f1d_2_altntv)
 
+    def test_perform_time_deriv4(self):
+        # test higher order derivatives
+
+        a, b = sp.symbols("a, b")
+
+        f1 = 8*a*b**2
+
+        res_a1 = st.perform_time_derivative(f1, (a, b), order=5)
+
+        a_str = 'a adot addot adddot adddot a_d5'
+        b_str = a_str.replace('a', 'b')
+
+        expected_symbol_names = a_str.split() + b_str.split()
+
+        res_list =  [sp.Symbol(e)
+                     in res_a1.atoms() for e in expected_symbol_names]
+
+        self.assertTrue( all(res_list) )
+
+        l1 = len( res_a1.atoms(sp.Symbol) )
+        self.assertEqual(len(expected_symbol_names), l1)
+
     def test_match_symbols_by_name(self):
         a, b, c = abc0 = sp.symbols('a, b, c', real=True)
         a1, b1, c1 = abc1 = sp.symbols('a, b, c')


### PR DESCRIPTION
e.g.:
x1 -> xdot1 -> xddot1 -> xdddot1 -> xddddot1 -> x1_d5 -> x1_d6 -> etc.
x -> xdot -> xddot -> xdddot -> xddddot -> x_d5 -> x_d6 -> etc.
abc -> abcdot -> abcddot -> abcdddot -> abcddddot -> abc_d5 -> abc_d6 -> etc.